### PR TITLE
Improved gitrevision tag matching for vN.N.N tags.

### DIFF
--- a/seedtool/.githooks/gen_gitrevision
+++ b/seedtool/.githooks/gen_gitrevision
@@ -13,7 +13,7 @@ latesttag=`git describe --tags --abbrev=0 --always`
 
 # Compute number of revisions since last tag.
 revssince=`git rev-list $latesttag..HEAD --count`
-gitdescribe=`git describe --tags --long --always`
+gitdescribe=`git describe --tags --long --always --match='v*.*'`
 
 cat << EOF > $FILENAME
 // ---------------- IMPORTANT - GENERATED FILE ----------------


### PR DESCRIPTION
Now we only use tags for app version that match v*.* (like "v0.4.3") but not tags like "announce-01".