### PR TITLE
Slip39 error diagnostics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,3 @@
-* Need better diagnsotics for SLIP39 restore operations.
-
-* Add negative SLIP39 tests to selftest.
-
 * Update to bc_bip32 (waiting for Wolf).
 
 * Remove the ESP32 code from lethe.ino?
@@ -12,7 +8,9 @@
 
 * Add compatibility instructions for https://iancoleman.io/bip39/
 
-* Add Security Considerations section to README.md, in particular talk about custody of device, evil maid attack, and tamper evident measures.
+* Add Security Considerations section to README.md, in particular talk
+  about custody of device, evil maid attack, and tamper evident
+  measures.
 
 #### Semantic Versioning Reminder
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
-* Add power-on-self test diagnostics to the screen.
+* Need better diagnsotics for SLIP39 restore operations.
 
-* Need better diagnsotics for BIP39 and SLIP39 restore operations.
-
-* Add negative tests to selftest.
+* Add negative SLIP39 tests to selftest.
 
 * Update to bc_bip32 (waiting for Wolf).
 

--- a/seedtool/seed.h
+++ b/seedtool/seed.h
@@ -68,6 +68,8 @@ public:
     static size_t const MAX_SHARES = 16;
     static size_t const WORDS_PER_SHARE = 20;
     
+    static bool verify_share_checksum(uint16_t const * share);
+    
     static SLIP39ShareSeq * from_seed(Seed const * seed,
                                       size_t thresh,
                                       size_t nshares,
@@ -78,12 +80,15 @@ public:
     ~SLIP39ShareSeq();
 
     size_t numshares() const { return nshares; }
-    
+
     // Adds a copy of the argument, returns the share index.
     size_t add_share(uint16_t const * share);
 
     // Replace a share's value with a copy of the argument.
     void set_share(size_t ndx, uint16_t const * share);
+
+    // Delete the specified share, compact gaps.
+    void del_share(size_t ndx);
 
     // Read-only, don't free returned value.
     uint16_t const * get_share(size_t ndx) const;

--- a/seedtool/seed.h
+++ b/seedtool/seed.h
@@ -75,6 +75,9 @@ public:
                                       size_t nshares,
                                       void(*randgen)(uint8_t *, size_t));
 
+    //  Read-only, don't free returned value.
+    static char const * error_msg(int errval);
+
     SLIP39ShareSeq();
 
     ~SLIP39ShareSeq();

--- a/seedtool/seed.ino
+++ b/seedtool/seed.ino
@@ -60,6 +60,10 @@ Seed * BIP39Seq::restore_seed() const {
         : NULL;
 }
 
+bool SLIP39ShareSeq::verify_share_checksum(uint16_t const * share) {
+    return rs1024_verify_checksum(share, WORDS_PER_SHARE);
+}
+
 SLIP39ShareSeq * SLIP39ShareSeq::from_seed(Seed const * seed,
                                            size_t thresh,
                                            size_t nshares,
@@ -126,6 +130,16 @@ void SLIP39ShareSeq::set_share(size_t ndx, uint16_t const * share) {
     size_t sharesz = sizeof(uint16_t) * WORDS_PER_SHARE;
     shares[ndx] = (uint16_t *) malloc(sharesz);
     memcpy(shares[ndx], share, sharesz);
+}
+
+void SLIP39ShareSeq::del_share(size_t ndx) {
+    serial_assert(ndx < nshares);
+    if (shares[ndx])
+        free(shares[ndx]);
+    // Compact any created gap.
+    for (size_t ii = ndx; ii < nshares-1; ++ii)
+        shares[ii] = shares[ii+1];
+    nshares -= 1;
 }
 
 char * SLIP39ShareSeq::get_share_strings(size_t ndx) const {

--- a/seedtool/seed.ino
+++ b/seedtool/seed.ino
@@ -100,6 +100,20 @@ SLIP39ShareSeq * SLIP39ShareSeq::from_seed(Seed const * seed,
     return slip39;
 }
 
+char const * SLIP39ShareSeq::error_msg(int errval) {
+    char buffer[1024];
+    switch (errval) {
+        // max message size 18 chars                |----------------|
+    case ERROR_INVALID_SHARD_SET:			return "Invalid shard set";
+    case ERROR_DUPLICATE_MEMBER_INDEX:		return "Duplicate shard";
+    case ERROR_NOT_ENOUGH_MEMBER_SHARDS:	return "Not enough shards";
+    default:
+        snprintf(buffer, sizeof(buffer), 		   "unknown err %d", errval);
+        return buffer;
+        // max message size 18 chars                |----------------|
+    }
+}
+
 SLIP39ShareSeq::SLIP39ShareSeq() {
     nshares = 0;
     memset(shares, 0x00, sizeof(shares));

--- a/seedtool/selftest.h
+++ b/seedtool/selftest.h
@@ -8,7 +8,7 @@ void selftest();
 // Used to run selftests from the UI.
 size_t selftest_numtests();
 String selftest_testname(size_t ndx);
-void selftest_testrun(size_t ndx);
+bool selftest_testrun(size_t ndx);
 
 // Used to populate dummy data in UI testing.
 const uint16_t * selftest_dummy_bip39();

--- a/seedtool/selftest.h
+++ b/seedtool/selftest.h
@@ -13,5 +13,6 @@ bool selftest_testrun(size_t ndx);
 // Used to populate dummy data in UI testing.
 const uint16_t * selftest_dummy_bip39();
 const uint16_t * selftest_dummy_slip39(size_t ndx);
+const uint16_t * selftest_dummy_slip39_alt(size_t ndx);
 
 #endif // SELFTEST_H

--- a/seedtool/userinterface.h
+++ b/seedtool/userinterface.h
@@ -4,6 +4,7 @@
 #define USERINTERFACE_H
 
 enum UIState {
+    INVALID_STATE = -1,
     SELF_TEST,
     INTRO_SCREEN,
     SEEDLESS_MENU,

--- a/seedtool/userinterface.ino
+++ b/seedtool/userinterface.ino
@@ -131,6 +131,10 @@ void self_test() {
     // case we failed the last test.
     for (int ndx = 0; ndx < numtests+1; ++ndx) {
 
+        // If any key is pressed, skip remaining self test.
+        if (g_keypad.getKey() != NO_KEY)
+            break;
+        
         // Append each test name to the bottom of the displayed list.
         size_t row = ndx;
         if (row > NLINES - 1) {
@@ -146,7 +150,7 @@ void self_test() {
             lines[row] = selftest_testname(ndx).c_str();
         } else {
             // ran last test and it passed
-            lines[row] = "";
+            lines[row] = "TESTS PASSED";
         }
 
         // Display the current list.


### PR DESCRIPTION
Added self-tests for:
test_slip39_verify_share_valid
test_slip39_verify_share_invalid
test_slip39_del_share
test_slip39_too_few
test_slip39_duplicate_share
test_slip39_extra_valid_share
test_slip39_extra_dup_share
test_slip39_invalid_share

Added GUI interstitials in appropriate spots for above.

Added 'D', '9' to enter SLIP-39 share w/ valid checksum, but from wrong set.

Added "hold any key to skip remaining self-tests" functionality.