### PR TITLE
Default to Waveshare v2.1 display

### DIFF
--- a/case/.gitignore
+++ b/case/.gitignore
@@ -1,1 +1,1 @@
-/gcode
+*.gcode

--- a/seedtool/gitrevision.h
+++ b/seedtool/gitrevision.h
@@ -13,10 +13,10 @@
 #ifndef GITREVISION_H
 #define GITREVISION_H
 
-#define GIT_BRANCH "------"
-#define GIT_SHORT_HASH "-------"
-#define GIT_LATEST_TAG "------"
-#define GIT_REVS_SINCE 0
-#define GIT_DESCRIBE "-----------------"
+#define GIT_BRANCH "waveshare-v2.1"
+#define GIT_SHORT_HASH "b88bff5"
+#define GIT_LATEST_TAG "v0.4.5"
+#define GIT_REVS_SINCE 7
+#define GIT_DESCRIBE "v0.4.5-7-gb88bff5"
 
 #endif // GITREVISION_H

--- a/seedtool/hardware.h
+++ b/seedtool/hardware.h
@@ -6,8 +6,25 @@
 #include <GxEPD2_BW.h>
 #include <Keypad.h>
 
+// Around April 2020 Waveshare started shipping a new version of the
+// "Waveshare 200x200, 1.54inch E-Ink display module".  The new
+// versions have "Rev2.1" printed under the title on the circuit side
+// of the display.  This new version requires a different driver
+// module from GxEPD2.
+//
+// If you have an *older* display (doesn't have "Rev2.1") uncomment
+// the following line:
+//
+// #define LEGACY_WAVESHARE
+
+#if !defined(LEGACY_WAVESHARE)
+#define EPD_DRIVER GxEPD2_154_D67
+#else
+#define EPD_DRIVER GxEPD2_154
+#endif
+
 // This is hard to hide/encapsulate.
-extern GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT> g_display;
+extern GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT> g_display;
 
 void hw_setup();
 void hw_green_led(int value);

--- a/seedtool/hardware.ino
+++ b/seedtool/hardware.ino
@@ -66,17 +66,17 @@ extern "C" {
 
 // Display
 #if defined(ESP32)
-GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT>
-    g_display(GxEPD2_154(/*CS=*/   21,
-                         /*DC=*/   17,
-                         /*RST=*/  16,
-                         /*BUSY=*/ 4));
+GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT>
+g_display(EPD_DRIVER(/*CS=*/   21,
+                     /*DC=*/   17,
+                     /*RST=*/  16,
+                     /*BUSY=*/ 4));
 #elif defined(SAMD51)
-GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT>
-    g_display(GxEPD2_154(/*CS=*/   PIN_A4,
-                         /*DC=*/   PIN_A3,
-                         /*RST=*/  PIN_A2,
-                         /*BUSY=*/ PIN_A1));
+GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT>
+g_display(EPD_DRIVER(/*CS=*/   PIN_A4,
+                     /*DC=*/   PIN_A3,
+                     /*RST=*/  PIN_A2,
+                     /*BUSY=*/ PIN_A1));
 #endif
 
 // Keypad


### PR DESCRIPTION
This PR addresses issue #34 

// Around April 2020 Waveshare started shipping a new version of the
// "Waveshare 200x200, 1.54inch E-Ink display module".  The new
// versions have "Rev2.1" printed under the title on the circuit side
// of the display.  This new version requires a different driver
// module from GxEPD2.
