### PR TITLE
Use GxEPD2/extras/sw_spi to choose legacy vs modern Waveshare driver instance at runtime.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "deps/bc-bip39"]
 	path = deps/bc-bip39
 	url = git@github.com:BlockchainCommons/bc-bip39.git
+[submodule "deps/GxEPD2"]
+	path = deps/GxEPD2
+	url = git@github.com:BlockchainCommons/GxEPD2.git

--- a/case/.gitignore
+++ b/case/.gitignore
@@ -1,1 +1,1 @@
-/gcode
+*.gcode

--- a/scripts/install-lethekit
+++ b/scripts/install-lethekit
@@ -44,8 +44,12 @@ fi
 
 lkroot=${args[0]}
 aroot=${args[1]}
-
 libpath="${aroot}/libraries"
+
+# First, check if GxEPD2 is already installed (as a directory), warn
+# and stop in this case.
+gxepd2_path="${aroot}/libraries/GxEPD2"
+[ -d ${gxepd2_path} ] && ! [ -L ${gxepd2_path} ] && echo "GxEPD2 already installed in ${libpath}. Please remove it; we need to replace with SW SPI enabled version." && exit 1
 
 declare -a libs=(
     bc-crypto-base
@@ -53,9 +57,10 @@ declare -a libs=(
     bc-slip39
     bc-bip39
     TRNG-for-ATSAMD51J19A-Adafruit-Metro-M4-
+    GxEPD2
 )
 
 for lib in "${libs[@]}"
 do
-    ln -fs ${lkroot}/deps/${lib} ${aroot}/libraries/
+    ln -fs ${lkroot}/deps/${lib} ${libpath}
 done

--- a/seedtool/gitrevision.h
+++ b/seedtool/gitrevision.h
@@ -13,10 +13,10 @@
 #ifndef GITREVISION_H
 #define GITREVISION_H
 
-#define GIT_BRANCH "waveshare-v2.1"
-#define GIT_SHORT_HASH "b88bff5"
+#define GIT_BRANCH "gxepd2-sw-spi"
+#define GIT_SHORT_HASH "81a3aff"
 #define GIT_LATEST_TAG "v0.4.5"
-#define GIT_REVS_SINCE 7
-#define GIT_DESCRIBE "v0.4.5-7-gb88bff5"
+#define GIT_REVS_SINCE 8
+#define GIT_DESCRIBE "v0.4.5-8-g81a3aff"
 
 #endif // GITREVISION_H

--- a/seedtool/gitrevision.h
+++ b/seedtool/gitrevision.h
@@ -13,10 +13,10 @@
 #ifndef GITREVISION_H
 #define GITREVISION_H
 
-#define GIT_BRANCH "------"
-#define GIT_SHORT_HASH "-------"
-#define GIT_LATEST_TAG "------"
-#define GIT_REVS_SINCE 0
-#define GIT_DESCRIBE "-----------------"
+#define GIT_BRANCH "waveshare-v2.1"
+#define GIT_SHORT_HASH "b88bff5"
+#define GIT_LATEST_TAG "v0.4.5"
+#define GIT_REVS_SINCE 7
+#define GIT_DESCRIBE "v0.4.5-7-gb88bff5"
 
 #endif // GITREVISION_H

--- a/seedtool/hardware.h
+++ b/seedtool/hardware.h
@@ -3,28 +3,11 @@
 #ifndef HARDWARE_H
 #define HARDWARE_H
 
-#include <GxEPD2_BW.h>
+#include <GxEPD2_GFX.h>
 #include <Keypad.h>
 
-// Around April 2020 Waveshare started shipping a new version of the
-// "Waveshare 200x200, 1.54inch E-Ink display module".  The new
-// versions have "Rev2.1" printed under the title on the circuit side
-// of the display.  This new version requires a different driver
-// module from GxEPD2.
-//
-// If you have an *older* display (doesn't have "Rev2.1") uncomment
-// the following line:
-//
-// #define LEGACY_WAVESHARE
-
-#if !defined(LEGACY_WAVESHARE)
-#define EPD_DRIVER GxEPD2_154_D67
-#else
-#define EPD_DRIVER GxEPD2_154
-#endif
-
 // This is hard to hide/encapsulate.
-extern GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT> g_display;
+extern GxEPD2_GFX *g_display;
 
 void hw_setup();
 void hw_green_led(int value);

--- a/seedtool/hardware.h
+++ b/seedtool/hardware.h
@@ -6,8 +6,25 @@
 #include <GxEPD2_BW.h>
 #include <Keypad.h>
 
+// Around April 2020 Waveshare started shipping a new version of the
+// "Waveshare 200x200, 1.54inch E-Ink display module".  The new
+// versions have "Rev2.1" printed under the title on the circuit side
+// of the display.  This new version requires a different driver
+// module from GxEPD2.
+//
+// If you have an *older* display (doesn't have "Rev2.1") uncomment
+// the following line:
+//
+// #define LEGACY_WAVESHARE
+
+#if !defined(LEGACY_WAVESHARE)
+#define EPD_DRIVER GxEPD2_154_D67
+#else
+#define EPD_DRIVER GxEPD2_154
+#endif
+
 // This is hard to hide/encapsulate.
-extern GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT> g_display;
+extern GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT> g_display;
 
 void hw_setup();
 void hw_green_led(int value);

--- a/seedtool/hardware.ino
+++ b/seedtool/hardware.ino
@@ -66,17 +66,17 @@ extern "C" {
 
 // Display
 #if defined(ESP32)
-GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT>
-    g_display(GxEPD2_154(/*CS=*/   21,
-                         /*DC=*/   17,
-                         /*RST=*/  16,
-                         /*BUSY=*/ 4));
+GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT>
+g_display(EPD_DRIVER(/*CS=*/   21,
+                     /*DC=*/   17,
+                     /*RST=*/  16,
+                     /*BUSY=*/ 4));
 #elif defined(SAMD51)
-GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT>
-    g_display(GxEPD2_154(/*CS=*/   PIN_A4,
-                         /*DC=*/   PIN_A3,
-                         /*RST=*/  PIN_A2,
-                         /*BUSY=*/ PIN_A1));
+GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT>
+g_display(EPD_DRIVER(/*CS=*/   PIN_A4,
+                     /*DC=*/   PIN_A3,
+                     /*RST=*/  PIN_A2,
+                     /*BUSY=*/ PIN_A1));
 #endif
 
 // Keypad

--- a/seedtool/hardware.ino
+++ b/seedtool/hardware.ino
@@ -4,6 +4,9 @@
 #undef ESP32
 #define SAMD51	1
 
+#define ENABLE_GxEPD2_GFX 1
+#include <GxEPD2_BW.h>
+
 #include "hardware.h"
 #include "util.h"
 
@@ -64,6 +67,8 @@ extern "C" {
 #define GREEN_LED	4
 #endif
 
+GxEPD2_GFX *g_display;
+
 // Display
 #if defined(ESP32)
 GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT>
@@ -72,11 +77,28 @@ g_display(EPD_DRIVER(/*CS=*/   21,
                      /*RST=*/  16,
                      /*BUSY=*/ 4));
 #elif defined(SAMD51)
-GxEPD2_BW<EPD_DRIVER, EPD_DRIVER::HEIGHT>
-g_display(EPD_DRIVER(/*CS=*/   PIN_A4,
-                     /*DC=*/   PIN_A3,
-                     /*RST=*/  PIN_A2,
-                     /*BUSY=*/ PIN_A1));
+
+// Around April 2020 Waveshare started shipping a new version of the
+// "Waveshare 200x200, 1.54inch E-Ink display module".  The new
+// versions have "Rev2.1" printed under the title on the circuit side
+// of the display.  This new version requires a different driver
+// module from GxEPD2 (GxEPD2_154_D67).
+//
+// We declare and initialize both modules and then probe the
+// controller at runtime to see which is connected.
+//
+GxEPD2_BW<GxEPD2_154, GxEPD2_154::HEIGHT>
+display_legacy(GxEPD2_154(/*CS=*/   PIN_A4,
+                          /*DC=*/   PIN_A3,
+                          /*RST=*/  PIN_A2,
+                          /*BUSY=*/ PIN_A1));
+GxEPD2_BW<GxEPD2_154_D67, GxEPD2_154_D67::HEIGHT>
+display_modern(GxEPD2_154_D67(/*CS=*/   PIN_A4,
+                              /*DC=*/   PIN_A3,
+                              /*RST=*/  PIN_A2,
+                              /*BUSY=*/ PIN_A1));
+#define SW_SCK 24
+#define SW_MOSI 23
 #endif
 
 // Keypad
@@ -101,15 +123,30 @@ Keypad g_keypad = Keypad(makeKeymap(keys_), rowPins_, colPins_, rows_, cols_);
 void hw_setup() {
     pinMode(BLUE_LED, OUTPUT);	// Blue LED
     digitalWrite(BLUE_LED, HIGH);
-    
+
     pinMode(GREEN_LED, OUTPUT);	// Green LED
     digitalWrite(GREEN_LED, LOW);
-    
-    g_display.init(115200);
-    g_display.setRotation(1);
 
     Serial.begin(115200);
-    
+
+    // Initialize both versions of the display instance.
+    display_modern.epd2.init(SW_SCK, SW_MOSI, 115200, true, false);
+    display_modern.init(115200);
+    display_legacy.epd2.init(SW_SCK, SW_MOSI, 115200, true, false);
+    display_legacy.init(115200);
+
+    // Read a byte from the display instance to pick a version.
+    uint8_t read_legacy = display_legacy.epd2._readData();
+    serial_printf("read_legacy: readData=0x%02x\n", read_legacy);
+    g_display = read_legacy
+        ? static_cast<GxEPD2_GFX *>(&display_legacy)
+        : static_cast<GxEPD2_GFX *>(&display_modern);
+
+    // Switch back to HW SPI for performance.
+    g_display->epd2.init(-1, -1, 115200, true, false);
+
+    g_display->setRotation(1);
+
 #if defined(SAMD51)
     trngInit();
 #endif

--- a/seedtool/seedtool.ino
+++ b/seedtool/seedtool.ino
@@ -17,7 +17,7 @@ void setup() {
     // monitor launched before the tests run.
     //
     // delay(5000);
-    
+
     ui_reset_into_state(SELF_TEST);
 
     Serial.println("seedtool starting");

--- a/seedtool/userinterface.ino
+++ b/seedtool/userinterface.ino
@@ -50,13 +50,13 @@ int const H_FMB12 = 21;	// height
 int const YM_FMB12 = 4;	// y-margin
 
 void full_window_clear() {
-    g_display.firstPage();
+    g_display->firstPage();
     do
     {
-        g_display.setFullWindow();
-        g_display.fillScreen(GxEPD_WHITE);
+        g_display->setFullWindow();
+        g_display->fillScreen(GxEPD_WHITE);
     }
-    while (g_display.nextPage());
+    while (g_display->nextPage());
 }
 
 void display_printf(char *format, ...) {
@@ -66,7 +66,7 @@ void display_printf(char *format, ...) {
     vsnprintf(buff, sizeof(buff), format, args);
     va_end(args);
     buff[sizeof(buff)/sizeof(buff[0])-1]='\0';
-    g_display.print(buff);
+    g_display->print(buff);
 }
 
 void interstitial_error(String const lines[], size_t nlines) {
@@ -75,30 +75,30 @@ void interstitial_error(String const lines[], size_t nlines) {
     int xoff = 16;
     int yoff = 6;
     
-    g_display.firstPage();
+    g_display->firstPage();
     do
     {
-        g_display.setPartialWindow(0, 0, 200, 200);
-        // g_display.fillScreen(GxEPD_WHITE);
-        g_display.setTextColor(GxEPD_BLACK);
+        g_display->setPartialWindow(0, 0, 200, 200);
+        // g_display->fillScreen(GxEPD_WHITE);
+        g_display->setTextColor(GxEPD_BLACK);
 
         int xx = xoff;
         int yy = yoff;
 
         for (size_t ii = 0; ii < nlines; ++ii) {
             yy += H_FSB9 + YM_FSB9;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
             serial_printf("%s", lines[ii].c_str());
             display_printf("%s", lines[ii].c_str());
         }
 
         yy = 190; // Absolute, stuck to bottom
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
         display_printf("%", GIT_DESCRIBE);
     }
-    while (g_display.nextPage());
+    while (g_display->nextPage());
 
     while (true) {
         char key;
@@ -154,36 +154,36 @@ void self_test() {
         }
 
         // Display the current list.
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff;
         
             yy += 1*(H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("Running self tests:");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("Running self tests:");
 
             yy += 10;
 
             for (size_t ii = 0; ii < NLINES; ++ii) {
                 yy += 1*(H_FMB9 + YM_FMB9);
-                g_display.setFont(&FreeMonoBold9pt7b);
-                g_display.setCursor(xx, yy);
+                g_display->setFont(&FreeMonoBold9pt7b);
+                g_display->setCursor(xx, yy);
                 display_printf("%s", lines[ii].c_str());
             }
 
             yy = 190; // Absolute, stuck to bottom
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
             display_printf("%", GIT_DESCRIBE);
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
 
         // If the test failed, abort (leaving status on screen).
         if (!last_test_passed) {
@@ -204,54 +204,54 @@ void intro_screen() {
     int xoff = 16;
     int yoff = 6;
     
-    g_display.firstPage();
+    g_display->firstPage();
     do
     {
-        g_display.setPartialWindow(0, 0, 200, 200);
-        // g_display.fillScreen(GxEPD_WHITE);
-        g_display.setTextColor(GxEPD_BLACK);
+        g_display->setPartialWindow(0, 0, 200, 200);
+        // g_display->fillScreen(GxEPD_WHITE);
+        g_display->setTextColor(GxEPD_BLACK);
 
         int xx = xoff + 14;
         int yy = yoff + (H_FSB12 + YM_FSB12);
-        g_display.setFont(&FreeSansBold12pt7b);
-        g_display.setCursor(xx, yy);
-        g_display.println("LetheKit v0");
+        g_display->setFont(&FreeSansBold12pt7b);
+        g_display->setCursor(xx, yy);
+        g_display->println("LetheKit v0");
 
         yy += 6;
         
         xx = xoff + 24;
         yy += H_FSB12 + YM_FSB12;
-        g_display.setCursor(xx, yy);
+        g_display->setCursor(xx, yy);
         display_printf("Seedtool");
 
         xx = xoff + 50;
         yy += H_FSB9;
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
         display_printf("%s", GIT_LATEST_TAG);
 
         xx = xoff + 28;
         yy += 1*(H_FSB9 + 2*YM_FSB9);
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
-        g_display.println("Blockchain");
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
+        g_display->println("Blockchain");
 
         xx = xoff + 30;
         yy += H_FSB9 + 4;
-        g_display.setCursor(xx, yy);
-        g_display.println("Commons");
+        g_display->setCursor(xx, yy);
+        g_display->println("Commons");
 
         xx = xoff + 18;
         yy += H_FSB9 + YM_FSB9 + 10;
-        g_display.setCursor(xx, yy);
-        g_display.println("Press any key");
+        g_display->setCursor(xx, yy);
+        g_display->println("Press any key");
         
         xx = xoff + 24;
         yy += H_FSB9;
-        g_display.setCursor(xx, yy);
-        g_display.println("to continue");
+        g_display->setCursor(xx, yy);
+        g_display->println("to continue");
     }
-    while (g_display.nextPage());
+    while (g_display->nextPage());
 
     while (true) {
         char key;
@@ -268,36 +268,36 @@ void seedless_menu() {
     int xoff = 16;
     int yoff = 10;
     
-    g_display.firstPage();
+    g_display->firstPage();
     do
     {
-        g_display.setPartialWindow(0, 0, 200, 200);
-        // g_display.fillScreen(GxEPD_WHITE);
-        g_display.setTextColor(GxEPD_BLACK);
+        g_display->setPartialWindow(0, 0, 200, 200);
+        // g_display->fillScreen(GxEPD_WHITE);
+        g_display->setTextColor(GxEPD_BLACK);
 
         int xx = xoff;
         int yy = yoff + (H_FSB12 + YM_FSB12);
-        g_display.setFont(&FreeSansBold12pt7b);
-        g_display.setCursor(xx, yy);
-        g_display.println("No Seed");
+        g_display->setFont(&FreeSansBold12pt7b);
+        g_display->setCursor(xx, yy);
+        g_display->println("No Seed");
 
         yy = yoff + 3*(H_FSB9 + YM_FSB9);
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
-        g_display.println("A - Generate Seed");
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
+        g_display->println("A - Generate Seed");
         yy += H_FSB9 + 2*YM_FSB9;
-        g_display.setCursor(xx, yy);
-        g_display.println("B - Restore BIP39");
+        g_display->setCursor(xx, yy);
+        g_display->println("B - Restore BIP39");
         yy += H_FSB9 + 2*YM_FSB9;
-        g_display.setCursor(xx, yy);
-        g_display.println("C - Restore SLIP39");
+        g_display->setCursor(xx, yy);
+        g_display->println("C - Restore SLIP39");
 
         yy = 190; // Absolute, stuck to bottom
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
         display_printf("%", GIT_DESCRIBE);
     }
-    while (g_display.nextPage());
+    while (g_display->nextPage());
 
     while (true) {
         char key;
@@ -328,47 +328,47 @@ void generate_seed() {
         int xoff = 14;
         int yoff = 8;
     
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB12 + YM_FSB12);
-            g_display.setFont(&FreeSansBold12pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("Generate Seed");
+            g_display->setFont(&FreeSansBold12pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("Generate Seed");
 
             yy += 10;
         
             yy += H_FSB9 + YM_FSB9;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("Enter Dice Rolls");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("Enter Dice Rolls");
 
             yy += 10;
         
             yy += H_FMB12 + YM_FMB12;
-            g_display.setFont(&FreeMonoBold12pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeMonoBold12pt7b);
+            g_display->setCursor(xx, yy);
             display_printf("Rolls: %d\n", g_rolls.length());
             yy += H_FMB12 + YM_FMB12;
-            g_display.setCursor(xx, yy);
+            g_display->setCursor(xx, yy);
             display_printf(" Bits: %0.1f\n", g_rolls.length() * 2.5850);
 
             // bottom-relative position
             xx = xoff + 10;
             yy = Y_MAX - 2*(H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("Press * to clear");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("Press * to clear");
             yy += H_FSB9 + YM_FSB9;
-            g_display.setCursor(xx, yy);
-            g_display.println("Press # to submit");
+            g_display->setCursor(xx, yy);
+            g_display->println("Press # to submit");
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
     
         char key;
         do {
@@ -403,36 +403,36 @@ void seedy_menu() {
     int xoff = 16;
     int yoff = 10;
     
-    g_display.firstPage();
+    g_display->firstPage();
     do
     {
-        g_display.setPartialWindow(0, 0, 200, 200);
-        // g_display.fillScreen(GxEPD_WHITE);
-        g_display.setTextColor(GxEPD_BLACK);
+        g_display->setPartialWindow(0, 0, 200, 200);
+        // g_display->fillScreen(GxEPD_WHITE);
+        g_display->setTextColor(GxEPD_BLACK);
 
         int xx = xoff;
         int yy = yoff + (H_FSB12 + YM_FSB12);
-        g_display.setFont(&FreeSansBold12pt7b);
-        g_display.setCursor(xx, yy);
-        g_display.println("Seed Present");
+        g_display->setFont(&FreeSansBold12pt7b);
+        g_display->setCursor(xx, yy);
+        g_display->println("Seed Present");
 
         yy = yoff + 3*(H_FSB9 + YM_FSB9);
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
-        g_display.println("A - Display BIP39");
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
+        g_display->println("A - Display BIP39");
         yy += H_FSB9 + 2*YM_FSB9;
-        g_display.setCursor(xx, yy);
-        g_display.println("B - Generate SLIP39");
+        g_display->setCursor(xx, yy);
+        g_display->println("B - Generate SLIP39");
         yy += H_FSB9 + 2*YM_FSB9;
-        g_display.setCursor(xx, yy);
-        g_display.println("C - Wipe Seed");
+        g_display->setCursor(xx, yy);
+        g_display->println("C - Wipe Seed");
 
         yy = 190; // Absolute, stuck to bottom
-        g_display.setFont(&FreeSansBold9pt7b);
-        g_display.setCursor(xx, yy);
+        g_display->setFont(&FreeSansBold9pt7b);
+        g_display->setCursor(xx, yy);
         display_printf("%", GIT_DESCRIBE);
     }
-    while (g_display.nextPage());
+    while (g_display->nextPage());
 
     while (true) {
         char key;
@@ -466,26 +466,26 @@ void display_bip39() {
         int const yoff = 0;
         int const nrows = 5;
     
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("BIP39 Mnemonic");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("BIP39 Mnemonic");
             yy += H_FSB9 + YM_FSB9;
             
             yy += 6;
         
-            g_display.setFont(&FreeMonoBold12pt7b);
+            g_display->setFont(&FreeMonoBold12pt7b);
             for (int rr = 0; rr < nrows; ++rr) {
                 int wndx = scroll + rr;
-                g_display.setCursor(xx, yy);
+                g_display->setCursor(xx, yy);
                 display_printf("%2d %s", wndx+1, g_bip39->get_string(wndx).c_str());
                 yy += H_FMB12 + YM_FMB12;
             }
@@ -493,11 +493,11 @@ void display_bip39() {
             // bottom-relative position
             xx = xoff + 2;
             yy = Y_MAX - (H_FSB9) + 2;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("1,7-Up,Down #-Done");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("1,7-Up,Down #-Done");
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
         
         char key;
         do {
@@ -548,75 +548,75 @@ void config_slip39() {
         int xoff = 20;
         int yoff = 8;
     
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("Configure SLIP39");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("Configure SLIP39");
 
             yy += 10;
 
             yy += H_FMB12 + 2*YM_FMB12;
-            g_display.setFont(&FreeMonoBold12pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeMonoBold12pt7b);
+            g_display->setCursor(xx, yy);
             display_printf(" Thresh: %s", threshstr.c_str());
 
             if (!thresh_done) {
                 int xxx = xx + (9 * W_FMB12);
                 int yyy = yy - H_FMB12;
-                g_display.fillRect(xxx,
+                g_display->fillRect(xxx,
                                    yyy,
                                    W_FMB12 * threshstr.length(),
                                    H_FMB12 + YM_FMB12,
                                    GxEPD_BLACK);
-                g_display.setTextColor(GxEPD_WHITE);
-                g_display.setCursor(xxx, yy);
+                g_display->setTextColor(GxEPD_WHITE);
+                g_display->setCursor(xxx, yy);
                 display_printf("%s", threshstr.c_str());
-                g_display.setTextColor(GxEPD_BLACK);
+                g_display->setTextColor(GxEPD_BLACK);
             }
             
             yy += H_FMB12 + 2*YM_FMB12;
-            g_display.setCursor(xx, yy);
+            g_display->setCursor(xx, yy);
             display_printf("NShares: %s", nsharestr.c_str());
 
             if (thresh_done) {
                 int xxx = xx + (9 * W_FMB12);
                 int yyy = yy - H_FMB12;
-                g_display.fillRect(xxx,
+                g_display->fillRect(xxx,
                                    yyy,
                                    W_FMB12 * nsharestr.length(),
                                    H_FMB12 + YM_FMB12,
                                    GxEPD_BLACK);
-                g_display.setTextColor(GxEPD_WHITE);
-                g_display.setCursor(xxx, yy);
+                g_display->setTextColor(GxEPD_WHITE);
+                g_display->setCursor(xxx, yy);
                 display_printf("%s", nsharestr.c_str());
-                g_display.setTextColor(GxEPD_BLACK);
+                g_display->setTextColor(GxEPD_BLACK);
             }
 
             // bottom-relative position
             xx = xoff + 2;
             yy = Y_MAX - (H_FSB9) + 2;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
 
             if (!thresh_done) {
-                g_display.println("*-Clear    #-Next");
+                g_display->println("*-Clear    #-Next");
             } else {
                 // If nsharestr field is empty its a prev
                 if (nsharestr == " ")
-                    g_display.println("*-Prev     #-Done");
+                    g_display->println("*-Prev     #-Done");
                 else
-                    g_display.println("*-Clear    #-Done");
+                    g_display->println("*-Clear    #-Done");
             }
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
             
         char key;
         do {
@@ -686,29 +686,29 @@ void display_slip39() {
         int yoff = 0;
         int nrows = 5;
     
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
             display_printf("SLIP39 %d/%d",
                            sharendx+1, g_slip39_generate->numshares());
             yy += H_FSB9 + YM_FSB9;
             
             yy += 8;
         
-            g_display.setFont(&FreeMonoBold12pt7b);
+            g_display->setFont(&FreeMonoBold12pt7b);
             for (int rr = 0; rr < nrows; ++rr) {
                 int wndx = scroll + rr;
                 char const * word =
                     g_slip39_generate->get_share_word(sharendx, wndx);
-                g_display.setCursor(xx, yy);
+                g_display->setCursor(xx, yy);
                 display_printf("%2d %s", wndx+1, word);
                 yy += H_FMB12 + YM_FMB12;
             }
@@ -716,14 +716,14 @@ void display_slip39() {
             // bottom-relative position
             xx = xoff + 2;
             yy = Y_MAX - (H_FSB9) + 2;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
             if (sharendx < (g_slip39_generate->numshares()-1))
-                g_display.println("1,7-Up,Down #-Next");
+                g_display->println("1,7-Up,Down #-Next");
             else
-                g_display.println("1,7-Up,Down #-Done");
+                g_display->println("1,7-Up,Down #-Done");
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
         
         char key;
         do {
@@ -916,21 +916,21 @@ void restore_bip39() {
 
         state.compute_scroll();
 
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
             display_printf("BIP39 Mnemonic");
             yy += H_FSB9 + YM_FSB9;
 
-            g_display.setFont(&FreeMonoBold12pt7b);
+            g_display->setFont(&FreeMonoBold12pt7b);
             yy += 2;
 
             for (int rr = 0; rr < state.nrows; ++rr) {
@@ -940,39 +940,39 @@ void restore_bip39() {
 
                 if (wndx != state.selected) {
                     // Regular entry, not being edited
-                    g_display.setTextColor(GxEPD_BLACK);
-                    g_display.setCursor(xx, yy);
+                    g_display->setTextColor(GxEPD_BLACK);
+                    g_display->setCursor(xx, yy);
                     display_printf("%2d %s\n", wndx+1, word.c_str());
                 } else {
                     // Edited entry
                     if (state.unique_match()) {
                         // Unique, highlight entire word.
-                        g_display.fillRect(xx - 1,
+                        g_display->fillRect(xx - 1,
                                            yy - H_FMB12 + YM_FMB12,
                                            W_FMB12 * (word.length() + 3) + 3,
                                            H_FMB12 + YM_FMB12,
                                            GxEPD_BLACK);
         
-                        g_display.setTextColor(GxEPD_WHITE);
-                        g_display.setCursor(xx, yy);
+                        g_display->setTextColor(GxEPD_WHITE);
+                        g_display->setCursor(xx, yy);
 
                         display_printf("%2d %s\n", wndx+1, word.c_str());
 
                     } else {
                         // Not unique, highlight cursor.
-                        g_display.setTextColor(GxEPD_BLACK);
-                        g_display.setCursor(xx, yy);
+                        g_display->setTextColor(GxEPD_BLACK);
+                        g_display->setCursor(xx, yy);
             
                         display_printf("%2d %s\n", wndx+1, word.c_str());
 
-                        g_display.fillRect(xx + (state.pos+3)*W_FMB12,
+                        g_display->fillRect(xx + (state.pos+3)*W_FMB12,
                                            yy - H_FMB12 + YM_FMB12,
                                            W_FMB12,
                                            H_FMB12 + YM_FMB12,
                                            GxEPD_BLACK);
         
-                        g_display.setTextColor(GxEPD_WHITE);
-                        g_display.setCursor(xx + (state.pos+3)*W_FMB12, yy);
+                        g_display->setTextColor(GxEPD_WHITE);
+                        g_display->setCursor(xx + (state.pos+3)*W_FMB12, yy);
                         display_printf("%c", word.c_str()[state.pos]);
                     }
                 }
@@ -983,15 +983,15 @@ void restore_bip39() {
             // bottom-relative position
             xx = xoff;
             yy = Y_MAX - 2*(H_FSB9) + 2;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setTextColor(GxEPD_BLACK);
-            g_display.setCursor(xx, yy);
-            g_display.println("4,6-L,R 2,8-chr-,chr+");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setTextColor(GxEPD_BLACK);
+            g_display->setCursor(xx, yy);
+            g_display->println("4,6-L,R 2,8-chr-,chr+");
             yy += H_FSB9 + 2;
-            g_display.setCursor(xx, yy);
-            g_display.println("1,7-Up,Down #-Done");
+            g_display->setCursor(xx, yy);
+            g_display->println("1,7-Up,Down #-Done");
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
         
         char key;
         do {
@@ -1096,24 +1096,24 @@ void restore_slip39() {
             scroll = selected - 2;
         serial_printf("scroll = %d\n", scroll);
         
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("Enter SLIP39 Shares");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("Enter SLIP39 Shares");
             yy += H_FSB9 + YM_FSB9;
 
             xx = xoff + 20;
             yy += 16;
 
-            g_display.setFont(&FreeMonoBold12pt7b);
+            g_display->setFont(&FreeMonoBold12pt7b);
             for (int rr = 0; rr < disprows; ++rr) {
                 int sharendx = scroll + rr;
                 char buffer[32];
@@ -1125,18 +1125,18 @@ void restore_slip39() {
                     sprintf(buffer, "Restore");
                 }
                 
-                g_display.setCursor(xx, yy);
+                g_display->setCursor(xx, yy);
                 if (sharendx != selected) {
-                    g_display.println(buffer);
+                    g_display->println(buffer);
                 } else {
-                    g_display.fillRect(xx,
+                    g_display->fillRect(xx,
                                        yy - H_FMB12,
                                        W_FMB12 * strlen(buffer),
                                        H_FMB12 + YM_FMB12,
                                        GxEPD_BLACK);
-                    g_display.setTextColor(GxEPD_WHITE);
-                    g_display.println(buffer);
-                    g_display.setTextColor(GxEPD_BLACK);
+                    g_display->setTextColor(GxEPD_WHITE);
+                    g_display->println(buffer);
+                    g_display->setTextColor(GxEPD_BLACK);
                 }
 
                 yy += H_FMB12 + YM_FMB12;
@@ -1145,11 +1145,11 @@ void restore_slip39() {
             // bottom-relative position
             xx = xoff + 2;
             yy = Y_MAX - (H_FSB9) + 2;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
-            g_display.println("1,7-Up,Down #-Do");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
+            g_display->println("1,7-Up,Down #-Do");
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
         
         char key;
         do {
@@ -1237,21 +1237,21 @@ void enter_share() {
 
         state.compute_scroll();
 
-        g_display.firstPage();
+        g_display->firstPage();
         do
         {
-            g_display.setPartialWindow(0, 0, 200, 200);
-            // g_display.fillScreen(GxEPD_WHITE);
-            g_display.setTextColor(GxEPD_BLACK);
+            g_display->setPartialWindow(0, 0, 200, 200);
+            // g_display->fillScreen(GxEPD_WHITE);
+            g_display->setTextColor(GxEPD_BLACK);
 
             int xx = xoff;
             int yy = yoff + (H_FSB9 + YM_FSB9);
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setCursor(xx, yy);
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setCursor(xx, yy);
             display_printf("SLIP39 Share %d", g_restore_slip39_selected+1);
             yy += H_FSB9 + YM_FSB9;
 
-            g_display.setFont(&FreeMonoBold12pt7b);
+            g_display->setFont(&FreeMonoBold12pt7b);
             yy += 2;
 
             for (int rr = 0; rr < state.nrows; ++rr) {
@@ -1261,39 +1261,39 @@ void enter_share() {
 
                 if (wndx != state.selected) {
                     // Regular entry, not being edited
-                    g_display.setTextColor(GxEPD_BLACK);
-                    g_display.setCursor(xx, yy);
+                    g_display->setTextColor(GxEPD_BLACK);
+                    g_display->setCursor(xx, yy);
                     display_printf("%2d %s\n", wndx+1, word.c_str());
                 } else {
                     // Edited entry
                     if (state.unique_match()) {
                         // Unique, highlight entire word.
-                        g_display.fillRect(xx - 1,
+                        g_display->fillRect(xx - 1,
                                            yy - H_FMB12 + YM_FMB12,
                                            W_FMB12 * (word.length() + 3) + 3,
                                            H_FMB12 + YM_FMB12,
                                            GxEPD_BLACK);
         
-                        g_display.setTextColor(GxEPD_WHITE);
-                        g_display.setCursor(xx, yy);
+                        g_display->setTextColor(GxEPD_WHITE);
+                        g_display->setCursor(xx, yy);
 
                         display_printf("%2d %s\n", wndx+1, word.c_str());
 
                     } else {
                         // Not unique, highlight cursor.
-                        g_display.setTextColor(GxEPD_BLACK);
-                        g_display.setCursor(xx, yy);
+                        g_display->setTextColor(GxEPD_BLACK);
+                        g_display->setCursor(xx, yy);
             
                         display_printf("%2d %s\n", wndx+1, word.c_str());
 
-                        g_display.fillRect(xx + (state.pos+3)*W_FMB12,
+                        g_display->fillRect(xx + (state.pos+3)*W_FMB12,
                                            yy - H_FMB12 + YM_FMB12,
                                            W_FMB12,
                                            H_FMB12 + YM_FMB12,
                                            GxEPD_BLACK);
         
-                        g_display.setTextColor(GxEPD_WHITE);
-                        g_display.setCursor(xx + (state.pos+3)*W_FMB12, yy);
+                        g_display->setTextColor(GxEPD_WHITE);
+                        g_display->setCursor(xx + (state.pos+3)*W_FMB12, yy);
                         display_printf("%c", word.c_str()[state.pos]);
                     }
                 }
@@ -1304,15 +1304,15 @@ void enter_share() {
             // bottom-relative position
             xx = xoff;
             yy = Y_MAX - 2*(H_FSB9) + 2;
-            g_display.setFont(&FreeSansBold9pt7b);
-            g_display.setTextColor(GxEPD_BLACK);
-            g_display.setCursor(xx, yy);
-            g_display.println("4,6-L,R 2,8-chr-,chr+");
+            g_display->setFont(&FreeSansBold9pt7b);
+            g_display->setTextColor(GxEPD_BLACK);
+            g_display->setCursor(xx, yy);
+            g_display->println("4,6-L,R 2,8-chr-,chr+");
             yy += H_FSB9 + 2;
-            g_display.setCursor(xx, yy);
-            g_display.println("1,7-Up,Down #-Done");
+            g_display->setCursor(xx, yy);
+            g_display->println("1,7-Up,Down #-Done");
         }
-        while (g_display.nextPage());
+        while (g_display->nextPage());
         
         char key;
         do {


### PR DESCRIPTION
Around April 2020 Waveshare started shipping a new version of the "Waveshare 200x200, 1.54inch E-Ink display module".  The new versions have "Rev2.1" printed under the title on the circuit side of the display.  This new version requires a different driver module from GxEPD2 (GxEPD2_154_D67).

The author of GxEPD2 suggests using SW SPI to probe the controller at runtime to select the correct driver:
https://forum.arduino.cc/index.php?topic=487007.msg4573334#msg4573334

To try this branch out you need to manually replace two files in the GxEPD2 distribution:
```
    cd ~/Arduino/libraries/GxEPD2/extras/sw_spi/src
    cp GxEPD2_EPD.{h,cpp} ~/Arduino/libraries/GxEPD2/src/
```

After playing with this I'd recommend deleting and restoring your GxEPD2 library from the distro to restore the overwritten files ...