### PR TITLE
fix compiler warnings

### DIFF
--- a/seedtool/seed.h
+++ b/seedtool/seed.h
@@ -71,8 +71,8 @@ public:
     static bool verify_share_checksum(uint16_t const * share);
     
     static SLIP39ShareSeq * from_seed(Seed const * seed,
-                                      size_t thresh,
-                                      size_t nshares,
+                                      uint8_t thresh,
+                                      uint8_t nshares,
                                       void(*randgen)(uint8_t *, size_t));
 
     //  Read-only, don't free returned value.

--- a/seedtool/seed.ino
+++ b/seedtool/seed.ino
@@ -35,8 +35,8 @@ Seed::Seed(uint8_t const * i_data, size_t len) {
 
 void Seed::log() const {
     serial_printf("seed: ");
-    for (int ii = 0; ii < sizeof(data); ++ii)
-        serial_printf("%02x", (int) data[ii]);
+    for (size_t ii = 0; ii < sizeof(data); ++ii)
+        serial_printf("%02x", data[ii]);
     serial_printf("\n");
 }
 
@@ -65,10 +65,10 @@ bool SLIP39ShareSeq::verify_share_checksum(uint16_t const * share) {
 }
 
 SLIP39ShareSeq * SLIP39ShareSeq::from_seed(Seed const * seed,
-                                           size_t thresh,
-                                           size_t nshares,
+                                           uint8_t thresh,
+                                           uint8_t nshares,
                                            void(*randgen)(uint8_t *, size_t)) {
-    char * password = "";
+    const char * password = "";
     uint8_t group_threshold = 1;
     uint8_t group_count = 1;
     group_descriptor group = { thresh, nshares, NULL };
@@ -91,7 +91,7 @@ SLIP39ShareSeq * SLIP39ShareSeq::from_seed(Seed const * seed,
                              shares_buffer,
                              shares_buffer_size,
                              randgen);
-    serial_assert(rv == nshares);
+    serial_assert(rv == (int)nshares);
     serial_assert(words_in_each_share == WORDS_PER_SHARE);
 
     SLIP39ShareSeq * slip39 = new SLIP39ShareSeq();
@@ -101,7 +101,7 @@ SLIP39ShareSeq * SLIP39ShareSeq::from_seed(Seed const * seed,
 }
 
 char const * SLIP39ShareSeq::error_msg(int errval) {
-    char buffer[1024];
+    static char buffer[1024];
     switch (errval) {
         // max message size 18 chars                |----------------|
     case ERROR_INVALID_SHARD_SET:			return "Invalid shard set";
@@ -169,7 +169,7 @@ char const * SLIP39ShareSeq::get_share_word(size_t sndx, size_t wndx) const {
 
 Seed * SLIP39ShareSeq::restore_seed() const {
     uint8_t seed_data[Seed::SIZE];
-    char * password = "";
+    const char * password = "";
     last_rv = slip39_combine(const_cast<const uint16_t **>(shares),
                              WORDS_PER_SHARE,
                              nshares,

--- a/seedtool/selftest.ino
+++ b/seedtool/selftest.ino
@@ -30,7 +30,7 @@ uint16_t ref_bip39_words_bad_checksum[BIP39Seq::WORD_COUNT] =
  0x0494, 0x0039, 0x050d, 0x04f1
 };
 
-char* ref_bip39_mnemonics[BIP39Seq::WORD_COUNT] =
+const char* ref_bip39_mnemonics[BIP39Seq::WORD_COUNT] =
 {
  "mirror", "reject", "rookie", "talk",
  "pudding", "throw", "happy", "era",
@@ -39,7 +39,7 @@ char* ref_bip39_mnemonics[BIP39Seq::WORD_COUNT] =
 
 size_t const ref_slip39_thresh = 2;
 size_t const ref_slip39_nshares = 3;
-char* ref_slip39_shares[ref_slip39_nshares] =
+const char* ref_slip39_shares[ref_slip39_nshares] =
 {
  "check academic academic acid counter "
  "both course legs visitor squeeze "
@@ -77,7 +77,7 @@ uint16_t ref_slip39_words[ref_slip39_nshares][SLIP39ShareSeq::WORDS_PER_SHARE] =
 
 // These shares are *also* generated from seed="123456", but they use
 // a different random seed so they are not compatible with the others.
-char* ref_slip39_shares_alt[ref_slip39_nshares] =
+const char* ref_slip39_shares_alt[ref_slip39_nshares] =
 {
  "deny category academic acid buyer "
  "miracle game discuss hobo decision "
@@ -125,13 +125,13 @@ uint16_t ref_slip39_share_bad_checksum[SLIP39ShareSeq::WORDS_PER_SHARE] =
 // Clearly not random. Only use for tests.
 void fake_random(uint8_t *buf, size_t count) {
     uint8_t b = 0;
-    for(int i = 0; i < count; i++) {
+    for(size_t i = 0; i < count; i++) {
         buf[i] = b;
         b = b + 17;
     }
 }
 
-bool test_failed(char *format, ...) {
+bool test_failed(const char *format, ...) {
   char buff[8192];
   va_list args;
   va_start(args, format);
@@ -470,5 +470,5 @@ String selftest_testname(size_t ndx) {
 bool selftest_testrun(size_t ndx) {
     using namespace selftest_internal;
     serial_assert(ndx < g_numtests);
-    g_selftests[ndx].testfun();
+    return g_selftests[ndx].testfun();
 }

--- a/seedtool/userinterface.ino
+++ b/seedtool/userinterface.ino
@@ -59,7 +59,7 @@ void full_window_clear() {
     while (g_display.nextPage());
 }
 
-void display_printf(char *format, ...) {
+void display_printf(const char *format, ...) {
     char buff[1024];
     va_list args;
     va_start(args, format);
@@ -129,7 +129,7 @@ void self_test() {
     size_t numtests = selftest_numtests();
     // Loop, once for each test.  Need an extra trip at the end in
     // case we failed the last test.
-    for (int ndx = 0; ndx < numtests+1; ++ndx) {
+    for (size_t ndx = 0; ndx < numtests+1; ++ndx) {
 
         // If any key is pressed, skip remaining self test.
         if (g_keypad.getKey() != NO_KEY)
@@ -718,7 +718,7 @@ void display_slip39() {
             yy = Y_MAX - (H_FSB9) + 2;
             g_display.setFont(&FreeSansBold9pt7b);
             g_display.setCursor(xx, yy);
-            if (sharendx < (g_slip39_generate->numshares()-1))
+            if (sharendx < (int)(g_slip39_generate->numshares()-1))
                 g_display.println("1,7-Up,Down #-Next");
             else
                 g_display.println("1,7-Up,Down #-Done");
@@ -746,7 +746,7 @@ void display_slip39() {
             }
             break;
         case '#':	// next / done
-            if (sharendx < (g_slip39_generate->numshares()-1)) {
+            if (sharendx < (int)(g_slip39_generate->numshares()-1)) {
                 ++sharendx;
                 scroll = 0;
             } else {
@@ -829,7 +829,7 @@ struct WordListState {
     }
 
     void cursor_right() {
-        if (pos < strlen(refword(wordndx[selected])) - 1)
+        if (pos < (int)strlen(refword(wordndx[selected])) - 1)
             ++pos;
     }
     
@@ -1035,7 +1035,7 @@ void restore_bip39() {
         case '#':	// done
             {
                 uint16_t bip39_words[BIP39Seq::WORD_COUNT];
-                for (int ii = 0; ii < BIP39Seq::WORD_COUNT; ++ii)
+                for (size_t ii = 0; ii < BIP39Seq::WORD_COUNT; ++ii)
                     bip39_words[ii] = state.wordndx[ii];
                 BIP39Seq * bip39 = BIP39Seq::from_words(bip39_words);
                 Seed * seed = bip39->restore_seed();
@@ -1090,7 +1090,7 @@ void restore_slip39() {
         // Adjust the scroll to center the selection.
         if (selected < 2)
             scroll = 0;
-        else if (selected > g_slip39_restore->numshares())
+        else if (selected > (int)g_slip39_restore->numshares())
             scroll = g_slip39_restore->numshares() + 2 - disprows;
         else
             scroll = selected - 2;
@@ -1117,9 +1117,9 @@ void restore_slip39() {
             for (int rr = 0; rr < disprows; ++rr) {
                 int sharendx = scroll + rr;
                 char buffer[32];
-                if (sharendx < g_slip39_restore->numshares()) {
+                if (sharendx < (int)g_slip39_restore->numshares()) {
                     sprintf(buffer, "Share %d", sharendx+1);
-                } else if (sharendx == g_slip39_restore->numshares()) {
+                } else if (sharendx == (int)g_slip39_restore->numshares()) {
                     sprintf(buffer, "Add Share");
                 } else {
                     sprintf(buffer, "Restore");
@@ -1162,19 +1162,19 @@ void restore_slip39() {
                 selected -= 1;
             break;
         case '7':
-            if (selected < g_slip39_restore->numshares() + 1 + showrestore - 1)
+            if (selected < (int)g_slip39_restore->numshares() + 1 + showrestore - 1)
                 selected += 1;
             break;
         case '*':
             g_uistate = SEEDLESS_MENU;
             return;
         case '#':
-            if (selected < g_slip39_restore->numshares()) {
+            if (selected < (int)g_slip39_restore->numshares()) {
                 // Edit existing share
                 g_restore_slip39_selected = selected;
                 g_uistate = ENTER_SHARE;
                 return;
-            } else if (selected == g_slip39_restore->numshares()) {
+            } else if (selected == (int)g_slip39_restore->numshares()) {
                 // Add new (zeroed) share
                 uint16_t share[SLIP39ShareSeq::WORDS_PER_SHARE] =
                     { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1190,7 +1190,7 @@ void restore_slip39() {
                 // happening ..
                 full_window_clear();
                 
-                for (int ii = 0; ii < g_slip39_restore->numshares(); ++ii) {
+                for (size_t ii = 0; ii < g_slip39_restore->numshares(); ++ii) {
                     char * strings =
                         g_slip39_restore->get_share_strings(ii);
                     serial_printf("%d %s\n", ii+1, strings);

--- a/seedtool/util.h
+++ b/seedtool/util.h
@@ -3,7 +3,7 @@
 #ifndef _UTIL_H
 #define _UTIL_H
 
-void serial_printf(char *format, ...);
+void serial_printf(const char *format, ...);
 
 #define serial_assert(_exp) \
     do {                                                                \

--- a/seedtool/util.ino
+++ b/seedtool/util.ino
@@ -2,7 +2,7 @@
 
 #include "util.h"
 
-void serial_printf(char *format, ...) {
+void serial_printf(const char *format, ...) {
   char buff[1024];
   va_list args;
   va_start(args, format);

--- a/signed-cla/CLA.gorazdko.41F0EA1699A74C1E2FA41B538CF96BC3FF9DBBCE.asc
+++ b/signed-cla/CLA.gorazdko.41F0EA1699A74C1E2FA41B538CF96BC3FF9DBBCE.asc
@@ -1,0 +1,74 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+# Contributor License Agreement
+
+Version 1.0
+
+Name: Gorazd Kovacic
+
+E-Mail: gorazdko@gmail.com
+
+Legal Jurisdiction: Wyoming, United States of America
+
+Project: https://github.com/BlockchainCommons/bc-lethekit
+
+Date: 06-11-2020
+
+## Purpose
+
+This agreement gives Blockchain Commons, LLC the permission it needs in order to accept my contributions into its open software project and to manage the intellectual property in that project over time.
+
+## License
+
+I hereby license Blockchain Commons, LLC to:
+
+1.  do anything with my contributions that would otherwise infringe my copyright in them
+
+2.  do anything with my contributions that would otherwise infringe patents that I can or become able to license
+
+3.  sublicense these rights to others on any terms they like
+
+## Reliability
+
+I understand that Blockchain Commons will rely on this license.  I may not revoke this license.
+
+## Awareness
+
+I promise that I am familiar with legal rules, like ["work made for hire" rules](http://worksmadeforhire.com), that can give employers and clients ownership of intellectual property in work that I do.  I am also aware that legal agreements I might sign, like confidential information and invention assignment agreements, will usually give ownership of intellectual property in my work to employers, clients, and companies that I found.  If someone else owns intellectual property in my work, I need their permission to license it.
+
+## Copyright Guarantee
+
+I promise not to offer contributions to the project that contain copyrighted work that I do not have legally binding permission to contribute under these terms.  When I offer a contribution with permission, I promise to document in the contribution who owns copyright in what work, and how they gave permission to contribute it.  If I later become aware that one of my contributions may have copyrighted work of others that I did not have permission to contribute, I will notify Blockchain Commons, in confidence, immediately.
+
+## Patent Guarantee
+
+I promise not to offer contributions to the project that I know infringe patents of others that I do not have permission to contribute under these terms.
+
+## Open Source Guarantee
+
+I promise not to offer contributions that contain or depend on the work of others, unless that work is available under a license that [Blue Oak Council rates bronze or better](https://blueoakconcil.org/list), such as the MIT License, two- or three-clause BSD License, the Apache License Version 2.0, or the Blue Oak Model License 1.0.0.  When I offer a contribution containing or depending on others' work, I promise to document in the contribution who licenses that work, along with copies of their license terms.
+
+## Disclaimers
+
+***As far as the law allows, my contributions come as is, without any warranty or condition.  Other than under [Copyright Guarantee](#copyright-guarantee), [Patent Guarantee](#patent-guarantee), or [Open Source Guarantee](#open-source-guarantee), I will not be liable to anyone for any damages related to my contributions or this contributor license agreement, under any kind of legal claim.***
+
+- ---
+
+To sign this Contributor License Agreement, fill in `$name`, `$email`, and `$date` above. Then sign using GPG using the following command `gpg --armor --clearsign --output ./signed-cla/CLA.YOURGITHUBNAME.YOURGPGFINGERPRINT.asc CLA.md`, then either submit your signed Contributor License Agreement to this repo as a GPG signed Pull Request or email it to [ChristopherA@BlockchainCommons.com](mailto:ChristopherA@BlockchainCommons.com).
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCgAdFiEEQfDqFpmnTB4vpBtTjPlrw/+du84FAl7iodMACgkQjPlrw/+d
+u85mpA/+MJS6QwdawdJrB81iqCXj1DoANFDKuxb8BYfIW37AjODFDygs8+50LH+5
+q8rRVmHZCfE6yBNzSItB37FcKGK9tDSLtAXTCFwEK/0+AuLUhvlrdBRtZBdP+gjd
+uk5SW0iW2F5hxXQp962VzMGoxUf8U0dqI/9r0IFHWL2yaCdEI6mkS8yiZJxjU8le
+BfRvTvYRMXo4ggtffI7cT4iJ7auzatcXeGb7R00ye6UDUw1GNGg+I3a1JHH+I6GQ
+EaNasbBSsFAn6cprQetGOFVXe85dqznyeayjGIOYZuOcMT2y5FUk+czm/5F62fEh
+fs/29b2bHN6jX9MiF1mgwEjvGNi3a+Xgl4iXsrUa7TvuK3ZOtWaWp8i5VOwUlfZL
+d5HZZbCYNInU3Q5bSjl3TeJdiZ+I19NpzFOotLb4VMp945DPno0e1sfkbzMXT9EJ
+Sv3mf7d22/FbEOvfnkMicdGtCje/n/HBYhcb4FkUOkGvtWlU+Ny0jZ25usprpS4E
+iJ7YAreuOCDMciPPnd/swqmNe2QOUgVm0EeVFaa4bUtENFaOjbHD7P42q7sdAZgJ
+s3IaRVn61e0tSL0lX53mxZJxL93tVx1jBgqG9hWQ8Gl2mHEMN1s7aTZ4pUb7FOi0
+E6UGDewJH147NmvOQ6vKpa/o58+/JgXhIG2wyuEKH0tFfUMP22Y=
+=8uJl
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
## Abstract

This PR fixes compiler warnings regarding implicit (string) conversions, integer comparisons, a non-return value of a non-void function, etc.

I have tested this in serial monitor only (haven't gotten a display yet):
* [selftest_result.txt](https://github.com/BlockchainCommons/bc-lethekit/files/4767304/selftest_result.txt)

2 warnings remain as they are part of git submodules.

## Status
Ready for review:
- [x] GPG sign the contributor license agreement